### PR TITLE
updated tsconfig path for yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "script": "ts-node --project scripts/tsconfig.json scripts",
+    "script": "ts-node --project tsconfig.json scripts",
     "precodegen": "rimraf src/generated && yarn script template",
     "codegen": "graph codegen subgraph.yaml --output-dir src/generated",
     "postcodegen": "yarn script flatten",


### PR DESCRIPTION
I couldn't `yarn codegen` because the `tsconfig.json` file had been moved but its path wasn't updated in the script named `script`, outputting of the following mistake:

`TSError: ⨯ Unable to compile TypeScript:
error TS5083: Cannot read file 'D:\Documents\Programming\Avantgarde-finance\melon-subgraph\scripts\tsconfig.json'.`
