### PR TITLE
docs: updated yarn deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You are now ready to start development. Documentation is available [here](https:
 In order to deploy the subgraph locally, all you need to do is.
 
 ```bash
-yarn create && yarn deploy
+yarn make && yarn deploy
 ```
 
 ## Contributing


### PR DESCRIPTION
`yarn create` is not defined in package.json (instead `yarn make` is, which runs `graph create`)